### PR TITLE
Fix inbox v2 NPE and zero results when limit/offset in moduleSearchCriteria

### DIFF
--- a/inbox/src/main/java/org/egov/inbox/service/V2/validator/ValidatorDefaultImplementation.java
+++ b/inbox/src/main/java/org/egov/inbox/service/V2/validator/ValidatorDefaultImplementation.java
@@ -16,6 +16,8 @@ import org.springframework.util.ObjectUtils;
 import java.util.HashMap;
 import java.util.Map;
 
+import static org.egov.inbox.util.InboxConstants.LIMIT_CONSTANT;
+import static org.egov.inbox.util.InboxConstants.OFFSET_CONSTANT;
 import static org.egov.inbox.util.InboxConstants.SORT_BY_CONSTANT;
 import static org.egov.inbox.util.InboxConstants.SORT_ORDER_CONSTANT;
 
@@ -40,6 +42,11 @@ public class ValidatorDefaultImplementation implements SearchCriteriaValidatorIn
 
         HashMap<String,Object> moduleSearchCriteria = inboxRequest.getInbox().getModuleSearchCriteria();
 
+        // Remove pagination params — they are handled at the inbox level,
+        // not as ES search criteria. Leaving them causes invalid ES queries.
+        moduleSearchCriteria.remove(LIMIT_CONSTANT);
+        moduleSearchCriteria.remove(OFFSET_CONSTANT);
+
         // Check if all mandatory fields exist in search criteria
         Set<String> mandatoryTrueFields = isMandatoryMap.entrySet().stream()
             .filter(entry -> Boolean.TRUE.equals(entry.getValue()))
@@ -57,13 +64,15 @@ public class ValidatorDefaultImplementation implements SearchCriteriaValidatorIn
             String key = entry.getKey();
             Object value = entry.getValue();
 
-            if(!(key.equals(SORT_ORDER_CONSTANT) || key.equals(SORT_BY_CONSTANT))) {
+            // Skip pagination and sorting params — these are not search criteria
+            if(key.equals(SORT_ORDER_CONSTANT) || key.equals(SORT_BY_CONSTANT)
+                    || key.equals(LIMIT_CONSTANT) || key.equals(OFFSET_CONSTANT)) {
+                continue;
+            }
 
-                if (isMandatoryMap.get(key)) {
-                    if (ObjectUtils.isEmpty(value)) {
-                        errorMap.put("INVALID_SEARCH_CRITERIA", "Field cannot be null or empty: " + key);
-                    }
-                }
+            Boolean isMandatory = isMandatoryMap.get(key);
+            if (isMandatory != null && isMandatory && ObjectUtils.isEmpty(value)) {
+                errorMap.put("INVALID_SEARCH_CRITERIA", "Field cannot be null or empty: " + key);
             }
         }
 
@@ -89,13 +98,15 @@ public class ValidatorDefaultImplementation implements SearchCriteriaValidatorIn
             String key = entry.getKey();
             Object value = entry.getValue();
 
-            if(!(key.equals(SORT_ORDER_CONSTANT) || key.equals(SORT_BY_CONSTANT))) {
+            // Skip pagination and sorting params — these are not search criteria
+            if(key.equals(SORT_ORDER_CONSTANT) || key.equals(SORT_BY_CONSTANT)
+                    || key.equals(LIMIT_CONSTANT) || key.equals(OFFSET_CONSTANT)) {
+                continue;
+            }
 
-                if (isMandatoryMap.get(key)) {
-                    if (ObjectUtils.isEmpty(value)) {
-                        errorMap.put("INVALID_SEARCH_CRITERIA", "Field cannot be null or empty: " + key);
-                    }
-                }
+            Boolean isMandatory = isMandatoryMap.get(key);
+            if (isMandatory != null && isMandatory && ObjectUtils.isEmpty(value)) {
+                errorMap.put("INVALID_SEARCH_CRITERIA", "Field cannot be null or empty: " + key);
             }
         }
 

--- a/inbox/src/main/java/org/egov/inbox/util/InboxConstants.java
+++ b/inbox/src/main/java/org/egov/inbox/util/InboxConstants.java
@@ -21,6 +21,10 @@ public class InboxConstants {
 
     public static final String SORT_BY_CONSTANT = "sortBy";
 
+    public static final String LIMIT_CONSTANT = "limit";
+
+    public static final String OFFSET_CONSTANT = "offset";
+
     public static final String CURRENT_PROCESS_INSTANCE_CONSTANT = "currentProcessInstance";
 
     public static final String COUNT_CONSTANT = "count";


### PR DESCRIPTION
## Summary

- Strip `limit` and `offset` from `moduleSearchCriteria` before they reach the ES query builder, preventing invalid term queries with null field paths
- Skip pagination params in the validation loop (matching existing `sortOrder`/`sortBy` handling)
- Use null-safe Boolean check on `isMandatoryMap.get(key)` to prevent NPE on any unexpected search criteria key

## Problem

The DIGIT UI sends `limit` and `offset` inside `moduleSearchCriteria` (in addition to the top-level `inbox.limit`/`inbox.offset`). The validator in `ValidatorDefaultImplementation` already skips `sortOrder` and `sortBy` but not these pagination params, causing two bugs:

1. **NPE**: `isMandatoryMap.get(key)` returns `null` for keys not in the allowed search criteria config. Auto-unboxing `null` to `boolean` throws `NullPointerException` at line 62.

2. **Zero results**: The query builder (`InboxQueryBuilder.addModuleSearchCriteriaToBaseQuery`) creates ES `term` queries for ALL keys in `moduleSearchCriteria`. For `limit`/`offset`, which aren't in the allowed criteria config, it generates queries with `null` field paths — causing Elasticsearch to return zero matches despite data existing in the index.

## Changes

| File | Change |
|------|--------|
| `InboxConstants.java` | Add `LIMIT_CONSTANT` and `OFFSET_CONSTANT` |
| `ValidatorDefaultImplementation.java` | Strip `limit`/`offset` from map before validation; skip in loop; null-safe Boolean check |

## Test plan

- [ ] Send inbox v2 search with `limit`/`offset` in `moduleSearchCriteria` → should return results (was NPE or zero results)
- [ ] Send inbox v2 search without `limit`/`offset` in `moduleSearchCriteria` → should still work as before
- [ ] Send inbox v2 search with unknown key in `moduleSearchCriteria` → should not NPE (null-safe check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved search criteria validation to correctly handle pagination parameters during the validation process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->