### PR TITLE
fix: inbox v2 empty results when user roles are at state-level tenant

### DIFF
--- a/inbox/src/main/java/org/egov/inbox/service/WorkflowService.java
+++ b/inbox/src/main/java/org/egov/inbox/service/WorkflowService.java
@@ -333,7 +333,14 @@ public class WorkflowService {
         	
         	String statelevelTenantId=entry.getKey().split("\\.")[0];
         	
-            if(entry.getKey().equals(criteria.getTenantId()) || (entry.getValue().contains(FSMConstants.FSM_DSO) && entry.getKey().equals(statelevelTenantId)) ){
+            // Match if role tenantId equals criteria tenantId (exact city match),
+            // OR if role tenantId is the state-level prefix of criteria tenantId
+            // (e.g. roles tagged to "mz" should match criteria "mz.chimoio"),
+            // OR FSM_DSO special case for state-level matching.
+            String criteriaStateTenantId = criteria.getTenantId().split("\\.")[0];
+            if(entry.getKey().equals(criteria.getTenantId())
+                    || entry.getKey().equals(criteriaStateTenantId)
+                    || (entry.getValue().contains(FSMConstants.FSM_DSO) && entry.getKey().equals(statelevelTenantId)) ){
                 List<BusinessService> businessServicesByTenantId = new ArrayList();
                 if(entry.getKey().split("\\.").length==1){
                     businessServicesByTenantId = tenantIdToBuisnessSevicesMap.get(criteria.getTenantId());


### PR DESCRIPTION
## Summary

- Inbox v2 returns **empty results** when the user's roles are tagged to the state-level tenant (e.g. `mz`) but the inbox query targets a city-level tenant (e.g. `mz.chimoio`)
- `getActionableStatusesForRole()` in `WorkflowService` only did an **exact match** between `role.tenantId` and `criteria.tenantId`, so state-level roles never matched city-level queries
- DIGIT registers users and assigns roles at the **state-level** tenant — the exact match condition is too restrictive

## Root Cause

In `WorkflowService.getActionableStatusesForRole()` (line 336), the condition:

```java
if(entry.getKey().equals(criteria.getTenantId()) || ...)
```

Only matches when `role.tenantId == "mz.chimoio"` (exact city match). But DIGIT's user service stores roles at the state level (`mz`), so this never matches — producing an empty `StatusIdNameMap {}`, which means no ES query is executed, and the inbox returns 0 items.

## Fix

Add a **state-level prefix match**: extract the state root from `criteria.getTenantId()` and also accept roles tagged to that state root.

```java
String criteriaStateTenantId = criteria.getTenantId().split("\\.")[0];
if(entry.getKey().equals(criteria.getTenantId())        // exact city match
    || entry.getKey().equals(criteriaStateTenantId)      // state-level match (NEW)
    || (entry.getValue().contains(FSMConstants.FSM_DSO)  // FSM special case
        && entry.getKey().equals(statelevelTenantId)) ){
```

This is consistent with how the business services lookup already works (line 338-341): state-level entries (`split.length == 1`) are resolved via `criteria.getTenantId()`.

## Test Plan

- [x] Built and deployed patched inbox on local DIGIT environment
- [x] Verified inbox v2 returns complaints for `mz.chimoio` with user roles tagged to `mz`
- [x] State UUID map now populated correctly (`{uuid → PENDINGFORASSIGNMENT, ...}`)
- [ ] Verify existing `pg.citya` inbox still works (roles tagged to `pg`)
- [ ] Verify FSM inbox behavior unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workflow action eligibility determination to properly support multi-level administrative hierarchy matching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->