### PR TITLE
Update status count query to use correct ES query method

### DIFF
--- a/inbox/src/main/java/org/egov/inbox/repository/builder/V2/InboxQueryBuilder.java
+++ b/inbox/src/main/java/org/egov/inbox/repository/builder/V2/InboxQueryBuilder.java
@@ -239,7 +239,7 @@ public class InboxQueryBuilder implements QueryBuilderInterface {
 
     @Override
     public Map<String, Object> getStatusCountQuery(InboxRequest inboxRequest) {
-        Map<String, Object> baseEsQuery = getBaseESQueryBody(inboxRequest, Boolean.FALSE);
+        Map<String, Object> baseEsQuery = getESQuery(inboxRequest, Boolean.FALSE);
         appendStatusCountAggsNode(baseEsQuery);
         return baseEsQuery;
     }


### PR DESCRIPTION
- Replace getBaseESQueryBody() call with getESQuery() in getStatusCountQuery()
- Ensures consistent query building methodology across status count operations
- Aligns with established query builder patterns for Elasticsearch queries